### PR TITLE
Fix crash in MoveDex move view

### DIFF
--- a/Plugins/Tectonic MoveDex/Entry/MoveDex_Entry_Scene.rb
+++ b/Plugins/Tectonic MoveDex/Entry/MoveDex_Entry_Scene.rb
@@ -105,7 +105,7 @@ class MoveDex_Entry_Scene
             learningEntry[1]
         }
         @levelUpLearnables.reject! { |learningEntry|
-            !speciesInfoViewable?(learningEntry[1])
+            !speciesInfoViewable?(learningEntry[0])
         }
     end
 


### PR DESCRIPTION
Caused by wrong index into level up learner table. Maintains intended sorting by level up level.