### PR TITLE
[Bug] Properly exit Hisuian form creation if no Origin Ore

### DIFF
--- a/Plugins/Tectonic Content Scripts/Vendors.rb
+++ b/Plugins/Tectonic Content Scripts/Vendors.rb
@@ -219,6 +219,7 @@ def createHisuian
 	unless pbHasItem?(:ORIGINORE)
 		setSpeaker(HISUIAN_WITCH)
 		pbMessage(_INTL("I do not spy any Origin Ore among your possessions."))
+		return
 	end
 
 	actualSpecies = [:HGROWLITHE,:HVOLTORB,:HQWILFISH,:HSNEASEL,:HZORUA,:BASCULIN_2]

--- a/Plugins/Tectonic Content Scripts/Vendors.rb
+++ b/Plugins/Tectonic Content Scripts/Vendors.rb
@@ -307,6 +307,7 @@ def cloneMinorLegend
 	unless pbHasItem?(:ORIGINORE)
 		setSpeaker(HISUIAN_WITCH)
 		pbMessage(_INTL("I do not spy any Origin Ore among your possessions."))
+		return	
 	end
 
 	possibleSpecies = [:PHIONE,:TYPENULL,:COSMOG,:MELTAN,:KUBFU]


### PR DESCRIPTION
There's a secondary issue where her name doesn't seem to be popping up in subsequent textboxes despite the use of setSpeaker, but that's relatively low priority