### PR TITLE
[Bug] Make cursed Masked Villain fights be double battles when appropriate

### DIFF
--- a/Plugins/Tectonic Content Scripts/RecurringNPCRandomization.rb
+++ b/Plugins/Tectonic Content Scripts/RecurringNPCRandomization.rb
@@ -136,13 +136,13 @@ def getRandomNPCTrainerDetails(villainNumber,fightSection=0)
     trainerType += "_DOUBLE" if doubleBattle
     trainerName = ["Crimson", "Teal"][villainNumber]
 
-    return trainerType, trainerName, trainerVersion
+    return trainerType, trainerName, trainerVersion, doubleBattle
 end
 
 def randomNPCTrainerBattle(villainNumber,fightSection=0)
-    trainerType, trainerName, trainerVersion = getRandomNPCTrainerDetails(villainNumber,fightSection)
+    trainerType, trainerName, trainerVersion, doubleBattle = getRandomNPCTrainerDetails(villainNumber,fightSection)
 
-    setBattleRule("double") if trainerVersion == 0
+    setBattleRule("double") if doubleBattle
 
     return pbTrainerBattle(trainerType,trainerName,nil, false, trainerVersion)
 end


### PR DESCRIPTION
The curse modified the trainerVersion parameter which was used to check if the fight was against Imogene - instead, the doubleBattle boolean is checked directly