### PR TITLE
[Feature] Add tutorial message on OmniTutor initialisation

### DIFF
--- a/PBS/intl_.txt
+++ b/PBS/intl_.txt
@@ -57045,6 +57045,8 @@ Log Off
 .\|.\|.\|.\|.\|
 \ssOmniTutor now engaged.
 \ssOmniTutor now engaged.
+\ssThe OmniTutor can teach any move available through move reminding, move mentorship, and TMs you own.
+\ssThe OmniTutor can teach any move available through move reminding, move mentorship, and TMs you own.
 Organize Boxes
 Organize Boxes
 Withdraw Pokémon

--- a/PBS/items.txt
+++ b/PBS/items.txt
@@ -2704,7 +2704,7 @@ Pocket = 8
 Price = 0
 FieldUse = OnPokemon
 Flags = KeyItem
-Description = A mysterious data storage device which can be used to upgrade your PC.
+Description = A mysterious data storage device. Plug it into any PC to unlock The Omnitutor.
 #-------------------------------
 [ANCIENTSEAWATER]
 Name = Ancient Sea Water

--- a/Plugins/Tectonic Graphics and UI/Menus/PC/PokeCenterPC.rb
+++ b/Plugins/Tectonic Graphics and UI/Menus/PC/PokeCenterPC.rb
@@ -45,6 +45,7 @@ def pbPokeCenterPC
         pbMessage(_INTL("\\ssLoading Omni-Tutor..."))
         pbMessage(_INTL(".\\|.\\|.\\|.\\|.\\|"))
         pbMessage(_INTL("\\ssOmniTutor now engaged."))
+        pbMessage(_INTL("\\ssThe OmniTutor can teach any move available through move reminding, move mentorship, and TMs you own."))
         $PokemonGlobal.omnitutor_active = true
     end
 

--- a/Plugins/Tectonic Other/Event Helpers/Trainers.rb
+++ b/Plugins/Tectonic Other/Event Helpers/Trainers.rb
@@ -1,4 +1,6 @@
-def perfectTrainer(maxTrainerLevel=15,giveDrop=true)
+PERFECTED_TRAINERS_DROP_ITEMS = true
+
+def perfectTrainer(maxTrainerLevel=15,giveDrop=PERFECTED_TRAINERS_DROP_ITEMS)
 	blackFadeOutIn() {
 		setMySwitch('D',true)
 		setFollowerGone
@@ -7,23 +9,23 @@ def perfectTrainer(maxTrainerLevel=15,giveDrop=true)
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 
-def perfectAncientTrainer
+def perfectAncientTrainer(giveDrop=PERFECTED_TRAINERS_DROP_ITEMS)
 	blackFadeOutIn() {
 		setMySwitch('D',true)
 		setFollowerGone
 	}
 	pbMessage(_INTL("The fleeing trainer dropped some food!"))
-	pbReceiveItem(:VANILLATULUMBA)
+	pbReceiveItem(:VANILLATULUMBA) if giveDrop
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 
-def perfectDittoTrainer(maxTrainerLevel=15)
+def perfectDittoTrainer(maxTrainerLevel=15,giveDrop=PERFECTED_TRAINERS_DROP_ITEMS)
 	blackFadeOutIn() {
 		setMySwitch('D',true)
 		pbSEPlay("Cries/DITTO",50,50)
 		setFollowerGone
 	}
-	pbTrainerDropsItem(maxTrainerLevel)
+	pbTrainerDropsItem(maxTrainerLevel) if giveDrop
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 
@@ -32,11 +34,11 @@ def perfectAceTrainer(maxTrainerLevel=15)
 		setMySwitch('D',true)
 		setFollowerGone
 	}
-	pbTrainerDropsItem(maxTrainerLevel,4)
+	pbTrainerDropsItem(maxTrainerLevel,4) if giveDrop
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 
-def perfectDoubleTrainer(event1,event2,maxTrainerLevel = 15)
+def perfectDoubleTrainer(event1,event2,maxTrainerLevel = 15,giveDrop=PERFECTED_TRAINERS_DROP_ITEMS)
 	blackFadeOutIn() {
 		setMySwitch('D',true)
 		pbSetSelfSwitch(event1,'D',true)
@@ -44,11 +46,11 @@ def perfectDoubleTrainer(event1,event2,maxTrainerLevel = 15)
 		setFollowerGone(event1)
 		setFollowerGone(event2)
 	}
-	pbTrainerDropsItem(maxTrainerLevel,2,true)
+	pbTrainerDropsItem(maxTrainerLevel,2,true) if giveDrop
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 
-def perfectDoubleAncientTrainer(event1,event2)
+def perfectDoubleAncientTrainer(event1,event2,giveDrop=PERFECTED_TRAINERS_DROP_ITEMS)
 	blackFadeOutIn() {
 		setMySwitch('D',true)
 		pbSetSelfSwitch(event1,'D',true)
@@ -58,7 +60,7 @@ def perfectDoubleAncientTrainer(event1,event2)
 	}
 
 	pbMessage(_INTL("The fleeing trainers dropped some food!"))
-	pbReceiveItem(:VANILLATULUMBA,2)
+	pbReceiveItem(:VANILLATULUMBA,2) if giveDrop
     incrementGlobalVar(TRAINERS_PERFECTED_GLOBAL_VAR)
 end
 


### PR DESCRIPTION
Not sure what's up with the commit history here but the changes look right
Leaving as a PR so dialogue writing can be double-checked/edited, and for any intl purposes