### PR TITLE
Fix "Sucker Punch" failure message

### DIFF
--- a/Plugins/Tectonic Battle/Move Codes/Attack downsides/Move_Codes_ConditionalFailure.rb
+++ b/Plugins/Tectonic Battle/Move Codes/Attack downsides/Move_Codes_ConditionalFailure.rb
@@ -9,11 +9,19 @@ class PokeBattle_Move_FailsIfTargetActed < PokeBattle_Move
             return true
         end
         oppMove = @battle.choices[target.index][2]
-        if !oppMove ||
-           (oppMove.function != "UseMoveTargetIsAboutToUse" && # Me First
-           (target.movedThisRound? || oppMove.statusMove?))
+        if !oppMove
             @battle.pbDisplay(_INTL("But it failed, since #{target.pbThis(true)} already moved this turn!")) if show_message
             return true
+        end
+        if oppMove.function != "UseMoveTargetIsAboutToUse" # Me First
+            if target.movedThisRound?
+                @battle.pbDisplay(_INTL("But it failed, since #{target.pbThis(true)} already moved this turn!")) if show_message
+                return true
+            end
+            if oppMove.statusMove?
+                @battle.pbDisplay(_INTL("But it failed, since #{target.pbThis(true)} didn't choose to attack!")) if show_message
+                return true
+            end
         end
         return false
     end


### PR DESCRIPTION
Under certain conditions, would print "already moved this turn" when "didn't choose to attack" was appropriate

Had to untangle the condition for the second failure message, so the code is a bit longer than it used to be

Should probably be tested