### PR TITLE
Allow map names to be imported from metadata.txt

### DIFF
--- a/Plugins/-- MOD TEMPLATE --/metadata.txt
+++ b/Plugins/-- MOD TEMPLATE --/metadata.txt
@@ -1,6 +1,7 @@
 #-------------------------------
 [998]
 # Test Map
+ImportName = Test Map
 Outdoor = true
 ShowArea = false
 Bicycle = true

--- a/Plugins/Plugins read-me.txt
+++ b/Plugins/Plugins read-me.txt
@@ -19,3 +19,5 @@ trainertypes.txt
 metadata.txt
 
 Examples of using each can be found in the MOD TEMPLATE folder.
+
+If including new maps with your mod, include the map name in the ImportName field in metadata.txt, so that it can be included when Debug Mode imports it into MapInfos.rxdata.

--- a/Plugins/Tectonic Game Data/Compiled Data/MetaData.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/MetaData.rb
@@ -180,6 +180,7 @@ module GameData
         attr_reader :teleport_blocked
         attr_reader :saving_blocked
         attr_reader :no_team_editing
+        attr_reader :import_name
 
         DATA = {}
         DATA_FILENAME = "map_metadata.dat"
@@ -210,6 +211,7 @@ module GameData
           "TeleportBlocked"  => [23, "b"],
           "SavingBlocked"    => [24, "b"],
           "NoTeamEditing"    => [25, "b"],
+          "ImportName"       => [26, "s"],
        }
 
         extend ClassMethodsIDNumbers
@@ -269,6 +271,8 @@ module GameData
                  _INTL("Whether the player is prevented from saving the game on this map."),],
                 ["NoTeamEditing",    BooleanProperty,
                  _INTL("Whether the player is prevented from editing their team on this map."),],
+                ["ImportName",       StringProperty,
+                _INTL("The name to give the map if it's missing in MapInfos.rxdata.")]
             ]
         end
 
@@ -300,6 +304,7 @@ module GameData
             @saving_blocked		    = hash[:saving_blocked]
             @no_team_editing 		= hash[:no_team_editing]
             @defined_in_extension   = hash[:defined_in_extension] || false
+            @import_name            = hash[:import_name]
         end
 
         def property_from_string(str)
@@ -329,6 +334,7 @@ module GameData
             when "TeleportBlocked"  then return @teleport_blocked
             when "SavingBlocked"    then return @saving_blocked
             when "NoTeamEditing"    then return @no_team_editing
+            when "ImportName"       then return @import_name
             end
             return nil
         end
@@ -397,6 +403,7 @@ module Compiler
                             :player_F           => contents["PlayerF"],
                             :player_G           => contents["PlayerG"],
                             :player_H           => contents["PlayerH"],
+                            :import_name        => contents["ImportName"]
                         }
                         # Add metadata's data to records
                         GameData::Metadata.register(metadata_hash)
@@ -430,6 +437,7 @@ module Compiler
                             :saving_blocked	      	=> contents["SavingBlocked"],
                             :no_team_editing	    => contents["NoTeamEditing"],
                             :defined_in_extension => !baseFile,
+                            :import_name            => contents["ImportName"]
                         }
                         # Add metadata's data to records
                         GameData::MapMetadata.register(metadata_hash)

--- a/Plugins/Tectonic Game Data/Compiler/Compiler_EventConversion.rb
+++ b/Plugins/Tectonic Game Data/Compiler/Compiler_EventConversion.rb
@@ -78,7 +78,7 @@ module Compiler
 
   def edit_maps
     wallReplaceConvexID = GameData::TerrainTag.get(:WallReplaceConvex).id_number
-  
+    renamed_maps = 0
     # Iterate over all maps
     mapData = Compiler::MapData.new
     tilesets_data = load_data("Data/Tilesets.rxdata")
@@ -86,6 +86,15 @@ module Compiler
         map = mapData.getMap(id)
         next if !map || !mapData.mapinfos[id]
         mapName = mapData.mapinfos[id].name
+
+        # overwrite name if specified
+        map_metadata = GameData::MapMetadata.try_get(id)
+        new_name = map_metadata.import_name if map_metadata && map_metadata.import_name
+        if new_name and new_name != mapName
+          mapData.mapinfos[id].name = new_name
+          mapName = new_name
+          renamed_maps += 1
+        end
 
         # Grab the tileset here
         tileset = tilesets_data[map.tileset_id]
@@ -151,6 +160,10 @@ module Compiler
         else
           echoln("Unable to make any changes to: #{mapName} (#{id})")
         end
+    end
+    if renamed_maps > 0
+      echoln("Saving MapInfos after renaming #{renamed_maps} maps.")
+      save_data(mapData.mapinfos,"Data/MapInfos.rxdata")
     end
   end
 


### PR DESCRIPTION
This should allow users to include new maps from multiple mods, while correctly importing the map names into MapInfos.rxdata, without the need for manual conflict resolution.