### PR TITLE
Add save conversion for Jovan quest

### DIFF
--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -18,6 +18,6 @@ SaveData.register_conversion(:jovan_quest_3_3_0) do
         (4..11).each do |switch|
             badgeCount += 1 if globalSwitches[switch]
         end
-        $PokemonGlobal.shouldProcJovanCall = true if globalVariables[44] == 4 && badgeCount == 7
+        save_data[:global_metadata].shouldProcJovanCall = true if globalVariables[44] == 4 && badgeCount == 7
     end
 end

--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -15,9 +15,8 @@ SaveData.register_conversion(:jovan_quest_3_3_0) do
 
         # Prepare phone call if appropriate
         badgeCount = 0
-        $Trainer.badges.each_with_index do |hasBadge,index|
-            break if index >= TOTAL_BADGES
-            badgeCount += 1 if hasBadge
+        (4..11).each do |switch|
+            badgeCount += 1 if globalSwitches[switch]
         end
         $PokemonGlobal.shouldProcJovanCall = true if globalVariables[44] == 4 && badgeCount == 7
     end

--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -12,5 +12,13 @@ SaveData.register_conversion(:jovan_quest_3_3_0) do
         globalVariables[44] += 1 if selfSwitches[[60,45,'A']] # Jovan in Shipping Lane
         # Optional LuxTech event is already handled by checking Gym flag
         globalVariables[44] += 1 if selfSwitches[[155,73,'A']] # Jovan in Prizca West
+
+        # Prepare phone call if appropriate
+        badgeCount = 0
+        $Trainer.badges.each_with_index do |hasBadge,index|
+            break if index >= TOTAL_BADGES
+            badgeCount += 1 if hasBadge
+        end
+        $PokemonGlobal.shouldProcJovanCall = true if badgeCount == 7
     end
 end

--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -1,0 +1,16 @@
+SaveData.register_conversion(:jovan_quest_3_3_0) do
+    game_version '3.3.0'
+    display_title 'Converting Jovan quest for 3.3.0'
+    to_all do |save_data|
+        globalSwitches = save_data[:switches]
+        globalVariables = save_data[:variables]
+        selfSwitches = save_data[:self_switches]
+        itemBag = save_data[:bag]
+    
+        globalVariables[44] += 1 if selfSwitches[[138,18,'A']] # Jovan in Scenic Trail
+        globalVariables[44] += 1 if selfSwitches[[136,2,'C']] # Jovan on Bluepoint Beach/Tamarind on docks (TODO: handle player missing X-Ray)
+        globalVariables[44] += 1 if selfSwitches[[60,45,'A']] # Jovan in Shipping Lane
+        # Optional LuxTech event is already handled by checking Gym flag
+        globalVariables[44] += 1 if selfSwitches[[155,73,'A']] # Jovan in Prizca West
+    end
+end

--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -8,7 +8,14 @@ SaveData.register_conversion(:jovan_quest_3_3_0) do
         itemBag = save_data[:bag]
     
         globalVariables[44] += 1 if selfSwitches[[138,18,'A']] # Jovan in Scenic Trail
-        globalVariables[44] += 1 if selfSwitches[[136,2,'C']] # Jovan on Bluepoint Beach/Tamarind on docks (TODO: handle player missing X-Ray)
+        if selfSwitches[[136,2,'C']]
+            # Player has seen the Tamarind dock event and got the Poke X-ray
+            globalVariables[44] += 1
+        elsif selfSwitches[[26,4,'A']]  
+            # Player has not seen the Tamarind dock event, but has defeated the Avatar of Vigoroth (which is after getting the X-ray in the new update)
+            globalVariables[44] += 1
+            itemBag.pbStoreItem(:POKEXRAY, 1, false)
+        end
         globalVariables[44] += 1 if selfSwitches[[60,45,'A']] # Jovan in Shipping Lane
         # Optional LuxTech event is already handled by checking Gym flag
         globalVariables[44] += 1 if selfSwitches[[155,73,'A']] # Jovan in Prizca West

--- a/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
+++ b/Plugins/Tectonic Save Conversions/3.3/3.3Jovan.rb
@@ -19,6 +19,6 @@ SaveData.register_conversion(:jovan_quest_3_3_0) do
             break if index >= TOTAL_BADGES
             badgeCount += 1 if hasBadge
         end
-        $PokemonGlobal.shouldProcJovanCall = true if badgeCount == 7
+        $PokemonGlobal.shouldProcJovanCall = true if globalVariables[44] == 4 && badgeCount == 7
     end
 end


### PR DESCRIPTION
To do:
- [x] Handle edge case of player who should have already gotten Poke X-Ray from Jovan on 3.3, but has not yet got it from Tamarind on 3.2
- [x] Fix Jovan phone call event not firing if save with 7 badges is converted
- [x] Handle the phone call to start the Forces of Nature quest if other prerequisites are met
- [x] Test and double check