### PR TITLE
Refactor "available by level" to include data in PBS

### DIFF
--- a/PBS/encounters.txt
+++ b/PBS/encounters.txt
@@ -1,26 +1,26 @@
 ﻿# See the documentation on the wiki to learn how to edit this file.
 #-------------------------------
 [002] # Windborn Island
-Land,21
+Land,21,60
     1,CRAMORANT,56,58
     1,JUMPLUFF,56,58
     1,PIDGEOT,56,58
     1,SWELLOW,56,58
     1,WORNET,56,58
-FloweryGrass,21
+FloweryGrass,21,60
     1,CHATOT,56,58
     1,FEAROW,56,58
     1,PAPELLUMEN,56,58
     1,TROPIUS,56,58
 #-------------------------------
 [003] # Kilna Turf
-Land,20
+Land,20,20
     20,DODUO,17,19
     20,MANKEY,17,19
     20,RHYHORN,17,19
     20,SANDSHREW,17,19
     20,YAMPER,17,19
-LandTall,20
+LandTall,20,20
     20,BLITZLE,17,19
     20,NIDORANfE,17,19
     20,NIDORANmA,17,19
@@ -34,7 +34,7 @@ Special
     1,AGEODUDE,15
 #-------------------------------
 [006] # LuxTech Campus
-FloweryGrass2,20
+FloweryGrass2,20,20
     28,MIMEJR,19,21
     28,PORYGON,19,21
     14,JOLTIK,19,21
@@ -44,12 +44,12 @@ Special
     1,GSLOWPOKE,15
 #-------------------------------
 [007] # Repora Forest
-Land,20
+Land,20,20
     40,MEOWTH,23,25
     20,NICKIT,23,25
     20,SHROOMISH,23,25
     20,SIZZLIPEDE,23,25
-LandSparse,20
+LandSparse,20,20
     20,GROWLITHE,23,25
     20,LARVESTA,23,25
     20,MURKROW,23,25
@@ -57,19 +57,19 @@ LandSparse,20
     20,VENONAT,23,25
 #-------------------------------
 [008] # Velenz
-LandTall,20
+LandTall,20,20
     25,GLAMEOW,24,26
     25,LOTAD,24,26
     25,NATU,24,26
     25,PUMPKABOO,24,26
 #-------------------------------
 [011] # Eleig River Crossing
-Land,20
+Land,20,20
     25,AXEW,20,22
     25,CHEWTLE,20,22
     25,DROWZEE,20,22
     25,GOSSIFLEUR,20,22
-Puddle,20
+Puddle,20,20
     20,BIDOOF,20,22
     20,BUIZEL,20,22
     20,GOLDEEN,20,22
@@ -85,7 +85,7 @@ Special
     1,MILCERY,15
 #-------------------------------
 [020] # Alloyed Thicket
-LandSparse,20
+LandSparse,20,60
     20,AMOONGUSS,53,55
     20,ARIADOS,53,55
     20,DITTO,53,55
@@ -93,7 +93,7 @@ LandSparse,20
     20,FERROTHORN,53,55
 #-------------------------------
 [025] # Grouz
-Land,20
+Land,20,20
     33,RUFFLET,18,20
     33,TYROGUE,18,20
     16,GOTHITA,18,20
@@ -102,12 +102,12 @@ Special
     1,TENTACOOL,10
 #-------------------------------
 [026] # Bluepoint Grotto
-DarkCave,20
+DarkCave,20,15
     25,GEODUDE,9,11
     25,NOIBAT,9,11
     25,SALANDIT,9,11
     25,WHISMUR,9,11
-LandSparse,20
+LandSparse,20,15
     25,DITTO,9,11
     25,FERROSEED,9,11
     25,PARAS,9,11
@@ -118,12 +118,12 @@ Special
     1,GMEOWTH,40
 #-------------------------------
 [030] # Windy Way
-Land,20
+Land,20,15
     33,RALTS,8,10
     33,ROCKRUFF,8,10
     16,HOPPIP,8,10
     16,MAREEP,8,10
-LandTall,20
+LandTall,20,15
     40,MWURMPLE,8,10
     20,STARLY,8,10
     20,STUNKY,8,10
@@ -137,7 +137,7 @@ Special
     1,MVULPIX,15
 #-------------------------------
 [034] # Battle Plaza
-FloweryGrass,20
+FloweryGrass,20,40
     20,HAPPINY,31,33
     20,LILLIPUP,31,33
     20,SAWK,34,36
@@ -154,27 +154,27 @@ Special
     1,ZIGZAGOON,10
 #-------------------------------
 [036] # Grouz Mine
-DarkCave,20
+DarkCave,20,20
     25,BELDUM,15,18
     25,KLINK,15,18
     25,MAGNEMITE,15,18
     25,SPINARAK,15,18
 #-------------------------------
 [037] # Svait
-Land,20
+Land,20,20
     25,MHOOTHOOT,23,25
     25,MIENFOO,23,25
     25,MISDREAVUS,23,25
     25,TEDDIURSA,23,25
 #-------------------------------
 [038] # Bluepoint Beach
-Land,20
+Land,20,15
     33,EXEGGCUTE,9,11
     16,GRUBBIN,9,11
     16,HOUNDOUR,9,11
     16,SANDYGAST,9,11
     16,WINGULL,9,11
-Puddle,20
+Puddle,20,15
     33,CLAMPERL,9,11
     17,HORSEA,9,11
     17,INKAY,9,11
@@ -186,7 +186,7 @@ Special
     1,ASANDSHREW,10
 #-------------------------------
 [040] # Gigalith's Guts
-DarkCave,20
+DarkCave,20,20
     25,ARON,18,20
     25,MROGGENROLA,18,20
     25,NOSEPASS,18,20
@@ -201,47 +201,47 @@ Special
     1,BONSLY,10
 #-------------------------------
 [051] # Foreclosed Tunnel
-DarkCave,20
+DarkCave,20,15
     25,GASTLY,9,11
     25,LITWICK,9,11
     25,ROLYCOLY,9,11
     25,TRAPINCH,9,11
-Mud,40
+Mud,40,15
     25,MACHOP,9,11
     25,MUDBRAY,9,11
     25,ONIX,9,11
     25,PHANPY,9,11
 #-------------------------------
 [053] # The Shelf
-Land,20
+Land,20,20
     40,SCYTHER,22,24
     20,MORELULL,22,24
     20,PANSEAR,22,24
     20,ZORUA,22,24
-Mud,40
+Mud,40,20
     33,SLOWPOKE,22,24
     16,EKANS,22,24
     16,PANPOUR,22,24
     16,STUFFUL,22,24
     16,WOOPER,22,24
-LandTall,20
+LandTall,20,20
     40,ODDISH,22,24
     20,PANSAGE,22,24
     20,ROOKIDEE,22,24
     20,SKIDDO,22,24
 #-------------------------------
 [055] # Lingering Delta
-Land,20
+Land,20,20
     25,BUNEARY,19,21
     25,CROAGUNK,19,21
     25,CUTIEFLY,19,21
     25,MVULLABY,19,21
-LandTall,20
+LandTall,20,20
     50,DEERLING_1,19,21
     25,ESPURR,19,21
     25,PSYDUCK,19,21
     25,YANMA,19,21
-Puddle,20
+Puddle,20,20
     40,POLIWAG,19,21
     20,BARBOACH,19,21
     20,SURSKIT,19,21
@@ -250,7 +250,7 @@ Special
     1,REMORAID,15
 #-------------------------------
 [056] # Novo Town
-FloweryGrass,20
+FloweryGrass,20,20
     25,CHERUBI,14,16
     25,DUCKLETT,14,16
     25,SMOOCHUM,14,16
@@ -263,12 +263,12 @@ Special
     1,AMEOWTH,15
 #-------------------------------
 [059] # Feebas' Fin
-Land,20
+Land,20,20
     40,GULPIN,13,15
     20,CHINGLING,13,15
     20,TAILLOW,13,15
     20,TIMBURR,13,15
-Puddle,20
+Puddle,20,20
     20,BINACLE,13,15
     20,FEEBAS,13,15
     20,MAGIKARP,13,15
@@ -279,12 +279,12 @@ Special
     1,CARVANHA,15
 #-------------------------------
 [060] # Shipping Lane
-Land,20
+Land,20,20
     25,IGGLYBUFF,14,16
     25,MSENTRET,14,16
     25,SLAKOTH,14,16
     25,VENIPEDE,14,16
-LandTall,20
+LandTall,20,20
     25,DIGLETT,14,16
     25,PIKIPEK,14,16
     25,PINECO,14,16
@@ -299,7 +299,7 @@ Special
     1,ABSOL,15
 #-------------------------------
 [067] # Old Ice Cream Shop
-LandSparse,20
+LandSparse,20,15
     33,SNORUNT,9,11
     17,AZURILL,9,11
     17,HONEDGE,9,11
@@ -348,7 +348,7 @@ Special
     1,SINISTEA,20
 #-------------------------------
 [117] # Ice Cave
-Land,20
+Land,20,20
     33,BERGMITE,23,25
     17,MMANTYKE,23,25
     17,PANCHAM,23,25
@@ -356,7 +356,7 @@ Land,20
     16,SNEASEL,23,25
 #-------------------------------
 [120] # Hollowed Layer
-DarkCave,20
+DarkCave,20,20
     20,BALTOY,18,20
     20,BRONZOR,18,20
     20,DUNSPARCE,18,20
@@ -364,7 +364,7 @@ DarkCave,20
     20,TYNAMO,18,20
 #-------------------------------
 [121] # Kilna Ascent
-Land,20
+Land,20,20
     20,CUBCHOO,22,24
     20,MPETILIL,22,24
     20,SNOM,22,24
@@ -376,7 +376,7 @@ Special
 [122] # LuxTech Sewers
 Special
     1,VOLTORB,21,23
-SewerFloor,20
+SewerFloor,20,20
     22,GRIMER,21,23
     22,MUNCHLAX,21,23
     22,SOLOSIS,21,23
@@ -399,7 +399,7 @@ Special
     1,TYRUNT,15
 #-------------------------------
 [129] # Barren Crater
-Land,20
+Land,20,20
     33,NINCADA,24,26
     16,BONSLY,24,26
     16,MTANGELA,24,26
@@ -409,13 +409,13 @@ Special
     1,LILLIPUP,15
 #-------------------------------
 [130] # Canal Desert
-LandSparse,20
+LandSparse,20,20
     20,CACNEA,44,46
     20,HELIOPTILE,44,46
     20,HIPPOPOTAS,44,46
     20,SANDILE,44,46
     20,SILICOBRA,44,46
-FloweryGrass,20
+FloweryGrass,20,25
     25,GLIGAR,44,46
     25,MARACTUS,44,46
     25,PACHIRISU,44,46
@@ -424,7 +424,7 @@ Special
     1,DARUMAKA,10
 #-------------------------------
 [135] # Nebula Ruins
-Cloud,20
+Cloud,20,25
     20,BLIPBUG,22,24
     20,CLEFFA,22,24
     20,MINIOR,22,24
@@ -432,25 +432,25 @@ Cloud,20
     20,WOOBAT,22,24
 #-------------------------------
 [136] # Casaba Villa
-Land,20
+Land,20,10
     40,PIDGEY,7,9
     40,SPRITZEE,7,9
     20,ELECTRIKE,7,9
     20,MSINISTEA,7,9
-FloweryGrass,20
+FloweryGrass,20,10
     25,ABRA,7,9
     25,BUDEW,7,9
     25,RATTATA,7,9
     25,TOGEPI,7,9
 #-------------------------------
 [138] # Scenic Trail
-Land,20
+Land,20,10
     20,CATERPIE,7,9
     20,IMPIDIMP,7,9
     20,LITLEO,7,9
     20,SEEDOT,7,9
     20,WEEDLE,7,9
-LandTall,20
+LandTall,20,10
     40,PICHU,7,9
     20,MEDITITE,7,9
     20,RIOLU,7,9
@@ -490,7 +490,7 @@ Special
     1,TOTODILE,10
 #-------------------------------
 [155] # Prizca West
-Land,20
+Land,20,40
     40,KOFFING,34,36
     20,AIPOM,34,36
     20,MVULPIX,34,36
@@ -507,7 +507,7 @@ Special
     1,ORICORIO,10
 #-------------------------------
 [180] # Blustery Bosk
-FloweryGrass2,20
+FloweryGrass2,20,60
     20,CORVIKNIGHT,55,57
     20,FEAROW,55,57
     20,LEDIAN,55,57
@@ -515,50 +515,50 @@ FloweryGrass2,20
     20,TOUCANNON,55,57
 #-------------------------------
 [182] # Spirit Atoll
-FloweryGrass,20
+FloweryGrass,20,60
     25,CHERRIM,56,58
     25,SNORLAX,56,58
     25,STARAPTOR,56,58
     25,VESPIQUEN,56,58
-FloweryGrass2,20
+FloweryGrass2,20,60
     25,CHIMECHO,56,58
     25,GOLDUCK,56,58
     25,LICKILICKY,56,58
     25,ROSERADE,56,58
 #-------------------------------
 [183] # Circuit Cave
-DarkCave,20
+DarkCave,20,60
     25,ELEKID,44,46
     25,MINUN,44,46
     25,MORPEKO,44,46
     25,PLUSLE,44,46
 #-------------------------------
 [185] # Eleig Stretch
-Land,20
+Land,20,25
     25,EMOLGA,32,34
     25,MSEVIPER,32,34
     25,MZANGOOSE,32,34
     25,STANTLER,32,34
-LandTall,25
+LandTall,25,25
     20,DEWPIDER,32,34
     20,DHELMISE,32,34
     20,HERACROSS,32,34
     20,LICKITUNG,32,34
     20,SEWADDLE,32,34
-Puddle,20
+Puddle,20,25
     40,CORPHISH,32,34
     20,CUFANT,32,34
     20,ILLUMISE,32,34
     20,VOLBEAT,32,34
 #-------------------------------
 [186] # Frostflow Farms
-LandTall,20
+LandTall,20,40
     20,AUDINO,31,33
     20,COTTONEE,32,34
     20,DEDENNE,32,34
     20,MILTANK,32,34
     20,TAUROS,32,34
-FloweryGrass2,20
+FloweryGrass2,20,40
     20,BOUFFALANT,32,34
     20,COMBEE,32,34
     20,SPHEAL,32,34
@@ -568,7 +568,7 @@ Special
     1,DURANT,40
 #-------------------------------
 [187] # Prizca East
-FloweryGrass2,20
+FloweryGrass2,20,40
     20,FURFROU,39,41
     20,INDEEDEE,39,41
     20,MINCCINO,39,41
@@ -578,7 +578,7 @@ Special
     1,SEVIPER,40
 #-------------------------------
 [192] # Field of Spires
-Land,20
+Land,20,60
     20,AMBIPOM,55,57
     20,CLAYDOL,55,57
     20,DUGTRIO,55,57
@@ -586,23 +586,23 @@ Land,20
     20,UNFEZANT,55,57
 #-------------------------------
 [193] # Volcanic Shore
-Land,20
+Land,20,40
     25,COMFEY,49,51
     25,CRABRAWLER,49,51
     25,LAPRAS,49,51
     25,PINCURCHIN,49,51
-LandSparse,20
+LandSparse,20,40
     34,MAGBY,49,51
     33,KECLEON,49,51
     33,SLUGMA,49,51
 #-------------------------------
 [196] # Boiling Cave
-DarkCave,20
+DarkCave,20,40
     25,DWEBBLE,49,51
     25,SOLROCK,49,51
     25,TORKOAL,49,51
     25,TURTONATOR,49,51
-Mud,40
+Mud,40,40
     25,SHUCKLE,49,51
     25,STUNFISK,49,51
     13,SHELLOS_1,49,51
@@ -617,12 +617,12 @@ Special
     1,EEVEE,20
 #-------------------------------
 [211] # Split Peaks
-Land,20
+Land,20,60
     25,ABSOL,49,51
     25,KOMALA,49,51
     25,PINSIR,49,51
     25,SPINDA,49,51
-LandSparse,20
+LandSparse,20,60
     25,DELIBIRD,49,51
     25,DRILBUR,49,51
     25,HAWLUCHA,49,51
@@ -631,7 +631,7 @@ Special
     1,BOUNSWEET,10
 #-------------------------------
 [212] # Ruins Digsite
-DarkCave,20
+DarkCave,20,20
     6,UNOWN_22,20,22
     3,UNOWN,20,22
     3,UNOWN_1,20,22
@@ -662,43 +662,43 @@ DarkCave,20
     3,UNOWN_9,20,22
 #-------------------------------
 [213] # Velenz Menagerie
-Land,20
+Land,20,20
     20,AMEOWTH,25,27
     20,ASANDSHREW,25,27
     20,AVULPIX,25,27
     20,GDARUMAKA,25,27
     20,YUNGOOS,25,27
-LandTall,20
+LandTall,20,20
     33,WURMPLE,25,27
     16,ARATTATA,25,27
     16,PATRAT,25,27
     16,SKWOVET,25,27
     16,ZIGZAGOON,25,27
-LandSparse,20
+LandSparse,20,20
     20,GPONYTA,25,27
     20,GYAMASK,25,27
     20,KARRABLAST,25,27
     20,SHELMET,25,27
     20,VULPIX,25,27
-Puddle,20
+Puddle,20,20
     33,GSLOWPOKE,25,27
     16,AGRIMER,25,27
     16,BELLSPROUT,25,27
     16,HOOTHOOT,25,27
     16,TANGELA,25,27
-FloweryGrass,20
+FloweryGrass,20,20
     33,PETILIL,25,27
     16,FARFETCHD,25,27
     16,FOMANTIS,25,27
     16,GFARFETCHD,25,27
     16,SENTRET,25,27
-DarkCave,20
+DarkCave,20,20
     33,BURMY,25,27
     16,ADIGLETT,25,27
     16,AGEODUDE,25,27
     16,GMEOWTH,25,27
     16,ROGGENROLA,25,27
-Mud,40
+Mud,40,40
     20,CARNIVINE,34,36
     20,CRAMORANT,34,36
     20,GSTUNFISK,34,36
@@ -707,7 +707,7 @@ Mud,40
     20,ZANGOOSE,34,36
 #-------------------------------
 [214] # Team Chasm HQ
-DarkCave,20
+DarkCave,20,20
     20,CARBINK,18,20
     20,DURALUDON,18,20
     20,ELGYEM,18,20
@@ -715,7 +715,7 @@ DarkCave,20
     20,MUNNA,18,20
 #-------------------------------
 [215] # Tempest Realm
-Cloud,20
+Cloud,20,60
     20,CASTFORM,64,66
     20,CRYOGONAL,64,66
     20,DRIFLOON,64,66
@@ -723,12 +723,12 @@ Cloud,20
     20,WAILMER,64,66
 #-------------------------------
 [216] # Highland Lake
-Land,20
+Land,20,40
     25,CHATOT,41,43
     25,FOONGUS,41,43
     25,ORANGURU,41,43
     25,PASSIMIAN,41,43
-LandTall,20
+LandTall,20,40
     25,DRAMPA,41,43
     25,FALINKS,41,43
     25,GIRAFARIG,41,43
@@ -737,25 +737,25 @@ Special
     1,KRABBY,10
 #-------------------------------
 [217] # Sweetrock Harbor
-Land,20
+Land,20,60
     40,APPLIN,49,51
     20,COMFEY,49,51
     20,FALINKS,49,51
     20,MILCERY,49,51
 #-------------------------------
 [218] # Abyssal Cavern
-ActiveWater,20
+ActiveWater,20,40
     25,CHINCHOU,48,50
     25,MFRILLISH,48,50
     25,RELICANTH,48,50
     25,WIMPOD,48,50
-DarkCave,20
+DarkCave,20,40
     34,LUNATONE,48,50
     33,MAREANIE,48,50
     33,WYNAUT,48,50
 #-------------------------------
 [219] # Stone Nest
-DarkCave,20
+DarkCave,20,20
     20,AXEW,25,27
     20,DRILBUR,25,27
     20,EKANS,25,27
@@ -763,14 +763,14 @@ DarkCave,20
     20,YAMASK,25,27
 #-------------------------------
 [220] # Ancient Sewers
-LandSparse,20
+LandSparse,20,20
     25,DRUDDIGON,41,43
     25,MIMIKYU,41,43
     25,SPIRITOMB,41,43
     25,YAMASK,41,43
 #-------------------------------
 [223] # Battle Plaza Underground
-LandSparse,20
+LandSparse,20,40
     20,ELGYEM,35,37
     20,GOLETT,35,37
     20,KLEFKI,35,37
@@ -794,7 +794,7 @@ Special
     1,KECLEON,40
 #-------------------------------
 [239] # Ocean Fishing Contest
-Puddle,10
+Puddle,10,40
     5,BINACLE,30,40
     5,CLAMPERL,30,40
     5,CLAUNCHER,30,40
@@ -869,7 +869,7 @@ Special
     1,JANGMOO,5
 #-------------------------------
 [257] # Cave of Hatching
-LandSparse,20
+LandSparse,20,60
     25,CUBONE,59,61
     25,LARVITAR,59,61
     25,MAGNEMITE,59,61
@@ -877,14 +877,14 @@ LandSparse,20
     20,KECLEON,59,61
 #-------------------------------
 [258] # Whitebloom Town
-Land,20
+Land,20,60
     25,BUNEARY,59,61
     25,KRICKETOT,59,61
     25,PICHU,59,61
     25,ROOKIDEE,59,61
 #-------------------------------
 [264] # Thunder Point
-Land,20
+Land,20,60
     20,BLASFEMMIE,55,57
     20,DEDENNE,55,57
     20,EMOLGA,55,57
@@ -892,7 +892,7 @@ Land,20
     20,SEISMAW,55,57
 #-------------------------------
 [282] # The Catacombs B1
-LandSparse,20
+LandSparse,20,60
     20,AEGISLASH,49,51
     20,DRUDDIGON,49,51
     20,DUSKNOIR,49,51
@@ -900,12 +900,12 @@ LandSparse,20
     20,NOIVERN,49,51
 #-------------------------------
 [288] # Underground River
-Puddle,20
+Puddle,20,40
     25,LUVDISC,48,50
     25,MANTYKE,48,50
     25,STARYU,48,50
     25,TENTACOOL,48,50
-LandSparse,20
+LandSparse,20,40
     25,CLAUNCHER,48,50
     25,DURANT,48,50
     25,HEATMOR,48,50
@@ -916,13 +916,13 @@ Special
     1,COTTONEE,20
 #-------------------------------
 [301] # County Park
-Land,20
+Land,20,20
     20,BUNNELBY,21,23
     20,FLETCHLING,21,23
     20,HATENNA,21,23
     20,KRICKETOT,21,23
     20,MAKUHITA,21,23
-FloweryGrass,20
+FloweryGrass,20,20
     25,LEDYBA,21,23
     25,SUNKERN,21,23
     25,SWABLU,21,23
@@ -935,7 +935,7 @@ Special
     1,DRIFLOON,15
 #-------------------------------
 [304] # Ruined Tower F1
-LandSparse,20
+LandSparse,20,40
     20,ABSOL,43,45
     20,CARKOL,43,45
     20,GOLETT,43,45
@@ -947,13 +947,13 @@ Special
     1,GPONYTA,15
 #-------------------------------
 [316] # Sandstone Estuary
-ActiveWater,20
+ActiveWater,20,40
     20,CARVANHA,49,51
     20,MANTYKE,49,51
     20,MFRILLISH,49,51
     20,REMORAID,49,51
     20,WAILMER,49,51
-LandSparse,20
+LandSparse,20,40
     20,CRABRAWLER,49,51
     20,EISCUE,49,51
     20,LAPRAS,49,51
@@ -969,7 +969,7 @@ Special
     1,WIMPOD,15
 #-------------------------------
 [326] # Carnation Graves
-DarkCave,20
+DarkCave,20,20
     40,CUBONE,20,22
     20,DUSKULL,20,22
     20,MAWILE,20,22
@@ -980,7 +980,7 @@ Special
     1,CASTFORM,40
 #-------------------------------
 [333] # Floral Maze
-FloweryGrass2,20
+FloweryGrass2,20,70
     20,APPLETUN,62,64
     20,GRIMMSNARL,62,64
     20,INDEEDEE,62,64
@@ -1006,7 +1006,7 @@ FloweryGrass2,20
     1,VIVILLON_9,62,64
 #-------------------------------
 [335] # Svait Sauna Underground
-Land,20
+Land,20,25
     20,DARUMAKA,23,25
     20,DWEBBLE,23,25
     20,SLUGMA,23,25
@@ -1014,7 +1014,7 @@ Land,20
     20,TURTONATOR,23,25
 #-------------------------------
 [342] # Carnation Tower F1
-LandSparse,20
+LandSparse,20,25
     20,ABSOL,32,34
     20,FALINKS,32,34
     20,FLABEBE_4,32,34
@@ -1026,7 +1026,7 @@ Special,1
     1,SHEDINJA,10
 #-------------------------------
 [349] # UB Portal
-DarkCave,20
+DarkCave,20,60
     13,BUZZWOLE,56,58
     13,NIHILEGO,56,58
     13,PHEROMOSA,56,58
@@ -1039,7 +1039,7 @@ DarkCave,20
     12,STAKATAKA,56,58
 #-------------------------------
 [353] # Crumbling Canyon B4
-DarkCave,20
+DarkCave,20,60
     20,LUNATONE,54,56
     20,RHYPERIOR,54,56
     20,SOLROCK,54,56
@@ -1047,7 +1047,7 @@ DarkCave,20
     20,TYRANITAR,54,56
 #-------------------------------
 [356] # Isle of Dragons
-LandSparse,20
+LandSparse,20,60
     22,GOOMY,13,15
     11,BAGON,13,15
     11,DEINO,13,15
@@ -1067,7 +1067,7 @@ Special
     20,HZORUA,10
 #-------------------------------
 [377] # Guardian Island
-Land,20
+Land,20,60
     20,COMFEY,60,62
     20,GUMSHOOS,60,62
     20,RIBOMBEE,60,62
@@ -1078,7 +1078,7 @@ Land,20
     6,ORICORIO_3,60,62
 #-------------------------------
 [383] # Mirror Tundra
-LandTall,20
+LandTall,20,60
     20,CARBINK,54,56
     20,CRYOGONAL,54,56
     20,HATTERENE,54,56
@@ -1098,7 +1098,7 @@ Special
     1,MINCCINO,15
 #-------------------------------
 [403] # Frozen Lake
-LandTall,20
+LandTall,20,60
     20,CARBINK,54,56
     20,CRYOGONAL,54,56
     20,HATTERENE,54,56
@@ -1106,7 +1106,7 @@ LandTall,20
     20,MNOCTOWL,54,56
 #-------------------------------
 [406] # Oasis System
-DarkCave,20
+DarkCave,20,60
     20,EELEKTROSS,53,55
     20,KROOKODILE,53,55
     20,MASQUERAIN,53,55
@@ -1114,14 +1114,14 @@ DarkCave,20
     20,ROTOM,53,55
 #-------------------------------
 [411] # Tri Island
-Land,20
+Land,20,70
     25,BOUNSWEET,13,15
     25,CASTFORM,13,15
     25,KRABBY,13,15
     25,NUMEL,13,15
 #-------------------------------
 [413] # Eventide Isle
-LandSparse,20
+LandSparse,20,60
     20,CLEFABLE,60,62
     20,GENGAR,60,62
     20,MUSHARNA,60,62
@@ -1129,7 +1129,7 @@ LandSparse,20
     20,URSALUNA,60,62
 #-------------------------------
 [414] # Eventide Peak
-LandSparse,20
+LandSparse,20,60
     20,CLEFABLE,60,62
     20,GENGAR,60,62
     20,MUSHARNA,60,62
@@ -1137,7 +1137,7 @@ LandSparse,20
     20,URSALUNA,60,62
 #-------------------------------
 [415] # Frigid Overlook
-Land,20
+Land,20,60
     20,CRYOGONAL,62,64
     20,EISCUE,62,64
     20,FROSMOTH,62,64
@@ -1145,7 +1145,7 @@ Land,20
     20,WEAVILE,62,64
 #-------------------------------
 [416] # Vernal Clearing
-Land,20
+Land,20,70
     20,ARCANINE,62,64
     20,CHERRIM,62,64
     20,PYROAR,62,64
@@ -1153,7 +1153,7 @@ Land,20
     20,TALONFLAME,62,64
 #-------------------------------
 [417] # Crackling Cave
-Cloud,20
+Cloud,20,70
     20,EELEKTROSS,62,64
     20,ELECTIVIRE,62,64
     20,EMOLGA,62,64
@@ -1161,7 +1161,7 @@ Cloud,20
     20,MANERGETIC,62,64
 #-------------------------------
 [425] # Shimmer Haven
-LandTall,20
+LandTall,20,70
     20,ACCELGOR,55,57
     20,ESCAVALIER,55,57
     20,FLORGES,55,57
@@ -1169,7 +1169,7 @@ LandTall,20
     20,PURUGLY,55,57
 #-------------------------------
 [428] # Steamy Valley
-FloweryGrass,20
+FloweryGrass,20,60
     20,GOLDUCK,60,62
     20,HYMNUS,60,62
     20,MISMAGIUS,60,62
@@ -1177,7 +1177,7 @@ FloweryGrass,20
     20,TORKOAL,60,62
 #-------------------------------
 [430] # Amber Hills
-LandSparse,20
+LandSparse,20,70
     20,DUBWOOL,62,64
     20,FLAPPLE,62,64
     20,GOGOAT,62,64
@@ -1185,7 +1185,7 @@ LandSparse,20
     20,SAHARICANE,62,64
 #-------------------------------
 [431] # Ship Graveyard
-Puddle,15
+Puddle,15,70
     20,DEWGONG,62,64
     20,JELLICENT,62,64
     20,KINGDRA,62,64

--- a/Plugins/Tectonic Game Data/Compiled Data/Encounters.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Encounters.rb
@@ -81,6 +81,7 @@ module Compiler
       new_format        = nil
       encounter_hash    = nil
       step_chances      = nil
+      available_levels  = nil
       need_step_chances = false   # Not needed for new format only
       probabilities     = nil     # Not needed for new format only
       current_type      = nil
@@ -162,12 +163,14 @@ module Compiler
               raise _INTL("Encounters for map '{1}' are defined twice.\r\n{2}", map_number, FileLineData.linereport)
             end
             step_chances = {}
+            available_levels = {}
             # Construct encounter hash
             encounter_hash = {
               :id           => key,
               :map          => map_number,
               :version      => map_version,
               :step_chances => step_chances,
+              :available_levels => available_levels,
               :types        => {},
               :defined_in_extension => !baseFile
             }

--- a/Plugins/Tectonic Game Data/Compiled Data/Species.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Species.rb
@@ -1015,6 +1015,7 @@ module Compiler
             enc_data.types.each do |key, slots|
                 next unless slots
                 earliestLevelForSlot = enc_data.available_levels[key]
+                next if earliestLevelForSlot.nil?
                 earliestLevelForSlot = [earliestLevelForSlot, SURFING_LEVEL].min if key == :ActiveWater
                 slots.each do |slot|
                     species = slot[1]

--- a/Plugins/Tectonic Game Data/Compiled Data/Species.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Species.rb
@@ -1014,8 +1014,7 @@ module Compiler
             # For each slot in that encounters data listing
             enc_data.types.each do |key, slots|
                 next unless slots
-                earliestLevelForSlot = enc_data.available_levels[key]
-                next if earliestLevelForSlot.nil?
+                earliestLevelForSlot = enc_data.available_levels[key] || 100
                 earliestLevelForSlot = [earliestLevelForSlot, SURFING_LEVEL].min if key == :ActiveWater
                 slots.each do |slot|
                     species = slot[1]

--- a/Plugins/Tectonic Game Data/Compiled Data/Species.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Species.rb
@@ -1011,12 +1011,10 @@ module Compiler
 
         # Checking every single map in the game for encounters
         GameData::Encounter.each_of_version do |enc_data|
-            earliestLevelForMap = getEarliestLevelForMap(enc_data.map)
-
             # For each slot in that encounters data listing
             enc_data.types.each do |key, slots|
                 next unless slots
-                earliestLevelForSlot = earliestLevelForMap
+                earliestLevelForSlot = enc_data.available_levels[key]
                 earliestLevelForSlot = [earliestLevelForSlot, SURFING_LEVEL].min if key == :ActiveWater
                 slots.each do |slot|
                     species = slot[1]
@@ -1085,14 +1083,6 @@ module Compiler
     def getEarliestLevelForItem(item_id)
         ITEMS_AVAILABLE_BY_CAP.each do |levelCapBracket, itemArray|
             next unless itemArray.include?(item_id)
-            return levelCapBracket
-        end
-        return 100
-    end
-
-    def getEarliestLevelForMap(map_id)
-        MAPS_AVAILABLE_BY_CAP.each do |levelCapBracket, mapArray|
-            next unless mapArray.include?(map_id)
             return levelCapBracket
         end
         return 100

--- a/Plugins/Tectonic MasterDex/Config.rb
+++ b/Plugins/Tectonic MasterDex/Config.rb
@@ -4,58 +4,6 @@ EHP_LEVEL = 50
 SEARCHES_STACK = true
 
 LEVEL_CAPS = [15,20,25,30,35,40,45,50,55,60,65,70]
-
-MAPS_AVAILABLE_BY_CAP = {
-	15 =>
-		[
-			136,138,30,	# Casaba Villa, Scenic Trail, Windy Way
-			51,38,26,	# Foreclosed Tunnel, Bluepoint Beach, Bluepoint Grotto
-			35,27,49,	# Impromptu Lab, Casaba Mart, Tourist's House
-			67,384 		# Old Ice Cream Shop, Casaba-Bluepoint Gatehouse
-		], 
-	20 =>
-		[
-			60,56,66,123,		# Shipping Lane, Novo Town, Novo Apartments Attic, Novo College
-			142,140,141, 		# Starters Store Maps
-			3,25,55,6,326,	 	# Kilna Turf, Grouz, Lingering Delta, LuxTech Campus, Carnation Graves
-			301,37,7,8,53, 		# County Park, Svait, Repora Forest, The Shelf
-			117,36,40, 			# Ice Cave, Grouz Mine, Gigalith's Guts
-			11,122,120, 		# Eleig River Crossing, LuxTech Sewers, Hollowed Layer
-			121,130,129,59, 	# Kilna Ascent, Canal Desert, Barren Crater, Feebas' Fin
-			96,98,126, 			# Luxtech Cold Storage, LuxTech Cold Storage Basement, Carnation Stockpile
-			4,86,392,       	# Scientist's House, Zigzagoon Nest, Turf-Grouz Gatehouse
-			323,87,103,92,    	# HQ Station Backroom, LuxTech Rec Center, Velenz Mart, Svait Lodge
-			32,71,74,			# Novo Apartments, Novo Apartments Room 103, Novo Apartments Room 203
-			91,65,85,			# Reading Ribombee Cafe, Nemeth Mart, Worried Man's House
-			213,214,219,		# Velenz Menagerie, Team Chasm HQ, Stone Nest
-			358,49,243,			# Dr. Hekata's House, Tourist's House, Chasm Base Mess Hall
-			251,305,321,	    # Samorn's House, Feebas' Fin Warehouse, Crater Station Backroom
-			212,90,13, 			# Ruins Digsite, Employee's House, Frost Station 1032
-			64,299,396			# M. Munna Den (Gigalith's Guts), Fin Center, Crater-Shelf Gatehouse
-		],
-	25 =>
-		[
-			335,185,135,			# Svait Sauna Underground, Eleig Stretch, Nebula Ruins
-		],
-	40 =>
-		[
-			155,29,47,		# Prizca West, Full Blast Records F2, Grand Hotal
-			34,183,180,		# Battle Fair, Circuit Cave, Priza West Mart
-			185,186,239,	# Eleig Stretch, Farm Placeholder, Ocean Fishing Zone
-			187,189,202,	# Prizca East, The Catacombs, Mountaineer's House
-			193,196,203,	# Lapras Shore, Boiling Cave, Skeevee Eevee Pub
-			211,216,	    # Split Peaks, Highland Lake
-			218,230,232,	# Abyssal Chamber, Galarian Fan's House, Biologist's House
-			234,220,228,	# Ranger Recruitment, Prizca Sewers East, Hidden Laboratory
-			223,250,288,	# Prizca Sewers West, Chasm Base Lab, Underground River
-		],
-	60 =>
-		[
-			217,316,	# Sweetrock Harbor, Sandstone Estuary
-			257,258,	# Cave of Hatching, Whitebloom Town
-			215,		# Sky Walk
-		],
-  }
   
 ITEMS_AVAILABLE_BY_CAP = {
 	35 => [:FIRESTONE,:WATERSTONE,:LEAFSTONE,:THUNDERSTONE,:DAWNSTONE,


### PR DESCRIPTION
Because of the way the filter rounds up, the guideline is
15 - Available on Casaba
20 - Available in Southern Makya
25 - Available with Chasm ID card
40 - Available post-surf
60 - Available post-rock climb
70 - Available post-game
For example, with surf, if your level cap is 35, you haven't beaten Yezera 3 yet, so you don't have surf. If you input 36, that should round up to 40, and then all the post-surf stuff should show as available.
There are some cases where it's more about the "intended" level than the "true" level. For example, the Chasm ID card assumes you match Yez 2's level, even though you don't need to, and Frostflow Farms is marked as post-surf despite the existence of the shortcut (but Carnation Tower is marked as level 25 because you *need* the Chasm-ID-locked sidequest to get into it)