### PR TITLE
base stat rewording

### DIFF
--- a/PBS/abilities_new.txt
+++ b/PBS/abilities_new.txt
@@ -1341,7 +1341,7 @@ Description = After knocking out any Pokémon, raises its Sp. Atk and Speed.
 #-------------------------------
 [OVERFLOWINGHEART]
 Name = Overflowing Heart
-Description = Copies the base stats of the Pokémon it switches in to replace.
+Description = Copies the unmodified stats of the Pokémon it switches in to replace.
 #-------------------------------
 [OVERTHINKING]
 Name = Overthinking
@@ -1478,7 +1478,7 @@ Description = The Pokémon's Dragon-type hits deal additional damage equal to ha
 #-------------------------------
 [PUZZLING]
 Name = Puzzling
-Description = Upon entry, creates a Puzzle Room for four turns, swapping base Attack and Sp. Atk.
+Description = Upon entry, creates a Puzzle Room for four turns, swapping unmodified Attack and Sp. Atk.
 #-------------------------------
 [QUARRELSOME]
 Name = Quarrelsome

--- a/PBS/moves.txt
+++ b/PBS/moves.txt
@@ -5140,7 +5140,7 @@ TotalPP = 10
 Target = NearOther
 FunctionCode = AverageUserTargetDefenses
 Flags = CanProtect
-Description = The user employs psychic power to average its base Defense and base Sp. Def stats with those of its target.
+Description = The user employs psychic power to average its unmodified Defense and Sp. Def stats with those of its target.
 #-------------------------------
 [HEALINGWISH]
 Name = Healing Wish
@@ -5292,7 +5292,7 @@ TotalPP = 10
 Target = NearOther
 FunctionCode = AverageUserTargetOffenses
 Flags = CanProtect
-Description = The user employs psychic power to average its base Attack and base Sp. Atk stats with those of the target.
+Description = The user employs psychic power to average its unmodified Attack and Sp. Atk stats with those of the target.
 #-------------------------------
 [POWERTRICK]
 Name = Power Trick
@@ -5303,7 +5303,7 @@ TotalPP = 10
 Target = User
 FunctionCode = SwapPhysicalStats
 Flags = CanSnatch
-Description = The user employs psychic power to switch its base Attack with its base Defense stat.
+Description = The user employs psychic power to switch its unmodified Attack with its unmodified Defense.
 #-------------------------------
 [PSYBEAM]
 Name = Psybeam

--- a/PBS/moves_new.txt
+++ b/PBS/moves_new.txt
@@ -5453,7 +5453,7 @@ TotalPP = 10
 Target = User
 FunctionCode = SwapSpecialStats
 Flags = CanSnatch
-Description = The user employs psychic power to switch its base Sp. Atk with its base Sp. Def stat.
+Description = The user employs psychic power to switch its unmodified Sp. Atk with its unmodified Sp. Def.
 #-------------------------------
 [EXPLOIT]
 Name = Exploit
@@ -7531,7 +7531,7 @@ Accuracy = 0
 TotalPP = 10
 Target = BothSides
 FunctionCode = StartSwapAttackingStats8
-Description = The user creates a puzzling area for eight turns in which Pokémon's base Attack and Sp. Atk are swapped.
+Description = The user creates a puzzling area for eight turns in which Pokémon's unmodified Attack and Sp. Atk are swapped.
 Animation = MAGICROOM
 #-------------------------------
 [SUGARBALL]


### PR DESCRIPTION
eliminated ambiguous references to "base stats" in move and ability descriptions. preferred wording is "unmodified stat."